### PR TITLE
Correct responsiveness on iphone XR

### DIFF
--- a/src/css/base.scss
+++ b/src/css/base.scss
@@ -647,7 +647,7 @@ section:first-of-type {
   }
 
   button {
-    padding: 2%;
+    padding: 3%;
   }
 
   h1 {
@@ -668,7 +668,7 @@ section:first-of-type {
   }
 
   .approve-button {
-    padding: 3%;
+    width: 25%;
   }
 
   .footer {
@@ -764,6 +764,19 @@ section:first-of-type {
     grid-row: 1;
     grid-column: 1;
     margin-top: -15%;
+  }
+
+  #request-form {
+    text-align: center;
+  }
+
+  #request-form button {
+    padding: 0%;
+    padding: 5px;
+  }
+
+  #request-form input {
+    margin: 5%;
   }
 
   #todays-trips {


### PR DESCRIPTION
This commit corrects the responsiveness issues on Iphone XR:
When logging in as agent the APPROVE trip button will now have the correct padding.

When logging in as traveler:
The trip request form will now have the correct padding and not be as jumbled.
The CALCULATE button on the trip request form will now have the correct amount of padding.

## Changes proposed by this PR
closes #40 

## What did you struggle on to complete?
I believe this issue has finally been resolved due to me actually being able to test the responsiveness during the design phase instead of having to push the changes to verify. This was not the best practice. Now I know to open my project in safari's development tools to test responsiveness for the different Apple devices. None of the other tools I was using rendered the same problems as my Iphone...Which was causing me to guess at the correct media query and hope once I pushed the change it would correct the issue. Now I have been able to replicate the problem in safari and I was able to see the issue corrected by the changes I made. 

## Checklist:
- [x] code has been linted with ESLint
- [x] I have reviewed my code
- [x] all issue criteria is completed 
- [x] I have fully styled all changes

## Helpful Resources:
[Reddit Thread with info about Iphone Responsiveness](https://www.reddit.com/r/apple/comments/a4wn25/iphone_xxrxsxs_max_and_ios_12_is_still_missing_in/)

